### PR TITLE
gensim.prepare speed up

### DIFF
--- a/pyLDAvis/_display.py
+++ b/pyLDAvis/_display.py
@@ -351,11 +351,11 @@ def save_html(data, fileobj, **kwargs):
     :func:`prepared_data_to_html` : output html representation of the visualization
     :func:`fig_to_dict` : output dictionary representation of the visualization
     """
-    if isinstance(fileobj, basestring):
+    try:
+        fileobj.write(prepared_data_to_html(data, **kwargs))
+    except AttributeError:
         fileobj = open(fileobj, 'w')
-    if not hasattr(fileobj, 'write'):
-        raise ValueError("fileobj should be a filename or a writable file")
-    fileobj.write(prepared_data_to_html(data, **kwargs))
+        fileobj.write(prepared_data_to_html(data, **kwargs))
 
 
 def save_json(data, fileobj):
@@ -374,8 +374,8 @@ def save_json(data, fileobj):
     :func:`save_html` : save html representation of a visualization to file
     :func:`prepared_data_to_html` : output html representation of the visualization
     """
-    if isinstance(fileobj, basestring):
+    try:
+        json.dump(data.to_dict(), fileobj, cls=NumPyEncoder)
+    except AttributeError:
         fileobj = open(fileobj, 'w')
-    if not hasattr(fileobj, 'write'):
-        raise ValueError("fileobj should be a filename or a writable file")
-    json.dump(data.to_dict(), fileobj, cls=NumPyEncoder)
+        json.dump(data.to_dict(), fileobj, cls=NumPyEncoder)

--- a/pyLDAvis/_prepare.py
+++ b/pyLDAvis/_prepare.py
@@ -129,7 +129,7 @@ def _job_chunks(l, n_jobs):
 
 def _find_relevance(log_ttd, log_lift, R, lambda_):
    relevance = lambda_ * log_ttd + (1 - lambda_) * log_lift
-   return relevance.T.apply(lambda s: s.order(ascending=False).index).head(R)
+   return relevance.T.apply(lambda s: s.sort_values(ascending=False).index).head(R)
 
 
 def _find_relevance_chunks(log_ttd, log_lift, R, lambda_seq):
@@ -151,7 +151,7 @@ def _topic_info(topic_term_dists, topic_proportion, term_frequency, term_topic_f
    default_term_info  = pd.DataFrame({'saliency': saliency, 'Term': vocab, \
                                       'Freq': term_frequency, 'Total': term_frequency, \
                                       'Category': 'Default'}). \
-      sort('saliency', ascending=False). \
+      sort_values(by='saliency', ascending=False). \
       head(R).drop('saliency', 1)
    ranks = np.arange(R, 0, -1)
    default_term_info['logprob'] = default_term_info['loglift'] = ranks
@@ -200,7 +200,7 @@ def _token_table(topic_info, term_topic_freq, vocab, term_frequency):
    token_table['Term'] = vocab[token_table.index.values].values
    # Normalize token frequencies:
    token_table['Freq'] = token_table.Freq / term_frequency[token_table.index]
-   return token_table.sort(['Term', 'Topic'])
+   return token_table.sort_values(by=['Term', 'Topic'])
 
 
 def _term_topic_freq(topic_term_dists, topic_freq, term_frequency):
@@ -280,7 +280,7 @@ def prepare(topic_term_dists, doc_topic_dists, doc_lengths, vocab, term_frequenc
    R = min(R, len(vocab))
 
    topic_freq       = (doc_topic_dists.T * doc_lengths).T.sum()
-   topic_proportion = (topic_freq / topic_freq.sum()).order(ascending=False)
+   topic_proportion = (topic_freq / topic_freq.sum()).sort_values(ascending=False)
    topic_order      = topic_proportion.index
    # reorder all data based on new ordering of topics
    topic_freq       = topic_freq[topic_order]

--- a/pyLDAvis/gensim.py
+++ b/pyLDAvis/gensim.py
@@ -28,18 +28,22 @@ def _extract_data(topic_model, corpus, dictionary, doc_topic_dists=None):
    term_freqs[term_freqs == 0] = beta
    doc_lengths = corpus_csc.sum(axis=0).A.ravel()
 
-   assert term_freqs.shape[0] == len(dictionary), 'Term frequencies and Dictionary have different sizes {} != {}'.format(term_freqs.shape[0], len(dictionary))
+   assert term_freqs.shape[0] == len(dictionary), 'Term frequencies and dictionary have different shape {} != {}'.format(term_freqs.shape[0], len(dictionary))
    assert doc_lengths.shape[0] == len(corpus), 'Document lengths and corpus have different sizes {} != {}'.format(doc_lengths.shape[0], len(corpus))
 
    if doc_topic_dists is None:
       gamma, _ = topic_model.inference(corpus)
       doc_topic_dists = gamma / gamma.sum(axis=1)[:, None]
 
+   assert doc_topic_dists.shape[1] == topic_model.num_topics, 'Document topics and number of topics do not match {} != {}'.format(doc_topic_dists.shape[0], topic_model.num_topics)
+
    # get the topic-term distribution straight from gensim without
    # iterating over tuples
    topic = topic_model.state.get_lambda()
    topic = topic / topic.sum(axis=1)[:, None]
-   topic_term_dists = topic[:, fnames_argsort].ravel()
+   topic_term_dists = topic[:, fnames_argsort]
+
+   assert topic_term_dists.shape[0] == doc_topic_dists.shape[1]
 
    return {'topic_term_dists': topic_term_dists, 'doc_topic_dists': doc_topic_dists,
            'doc_lengths': doc_lengths, 'vocab': vocab, 'term_frequency': term_freqs}

--- a/pyLDAvis/gensim.py
+++ b/pyLDAvis/gensim.py
@@ -35,13 +35,11 @@ def _extract_data(topic_model, corpus, dictionary, doc_topic_dists=None):
       gamma, _ = topic_model.inference(corpus)
       doc_topic_dists = gamma / gamma.sum(axis=1)[:, None]
 
+   # get the topic-term distribution straight from gensim without
+   # iterating over tuples
    topic = topic_model.state.get_lambda()
    topic = topic / topic.sum(axis=1)[:, None]
-   topic = topic[:, fnames_argsort]
-   topics_df = pd.DataFrame(data=topic, columns=dictionary.token2id)
-   topics_df = topics_df[vocab]
-
-   topic_term_dists = topics_df.values
+   topic_term_dists = topic[:, fnames_argsort].ravel()
 
    return {'topic_term_dists': topic_term_dists, 'doc_topic_dists': doc_topic_dists,
            'doc_lengths': doc_lengths, 'vocab': vocab, 'term_frequency': term_freqs}

--- a/pyLDAvis/gensim.py
+++ b/pyLDAvis/gensim.py
@@ -46,7 +46,7 @@ def _extract_data(topic_model, corpus, dictionary, doc_topic_dists=None):
    return {'topic_term_dists': topic_term_dists, 'doc_topic_dists': doc_topic_dists,
            'doc_lengths': doc_lengths, 'vocab': vocab, 'term_frequency': term_freqs}
 
-def prepare(topic_model, corpus, dictionary, doc_topic_dist=None, **kargs):
+def prepare(topic_model, corpus, dictionary, doc_topic_dist=None, **kwargs):
     """Transforms the Gensim TopicModel and related corpus and dictionary into
     the data structures needed for the visualization.
 
@@ -91,5 +91,5 @@ def prepare(topic_model, corpus, dictionary, doc_topic_dist=None, **kargs):
     ------
     See `pyLDAvis.prepare` for **kwargs.
     """
-    opts = fp.merge(_extract_data(topic_model, corpus, dictionary, doc_topic_dist), kargs)
+    opts = fp.merge(_extract_data(topic_model, corpus, dictionary, doc_topic_dist), kwargs)
     return vis_prepare(**opts)

--- a/pyLDAvis/gensim.py
+++ b/pyLDAvis/gensim.py
@@ -10,32 +10,43 @@ import pandas as pd
 from past.builtins import xrange
 from . import prepare as vis_prepare
 
-def _normalize(array):
-   return pd.DataFrame(array).\
-      apply(lambda row: row / row.sum(), axis=1).values
 
-def _extract_data(topic_model, corpus, dictionary):
-   doc_lengths = [sum([t[1] for t in doc]) for doc in corpus]
-
-   term_freqs_dict = fp.merge_with(sum, *corpus)
-
+def _extract_data(topic_model, corpus, dictionary, doc_topic_dists=None):
+   import gensim
+   
+   if not gensim.matutils.ismatrix(corpus):
+      corpus_csc = gensim.matutils.corpus2csc(corpus)
+   else:
+      corpus_csc = corpus
+   
    vocab = list(dictionary.token2id.keys())
    # TODO: add the hyperparam to smooth it out? no beta in online LDA impl.. hmm..
    # for now, I'll just make sure we don't ever get zeros...
    beta = 0.01
-   term_freqs = [term_freqs_dict.get(tid, beta) for tid in dictionary.token2id.values()]
+   fnames_argsort = np.asarray(list(dictionary.token2id.values()), dtype=np.int_)
+   term_freqs = corpus_csc.sum(axis=1).A.ravel()[fnames_argsort]
+   term_freqs[term_freqs == 0] = beta
+   doc_lengths = corpus_csc.sum(axis=0).A.ravel()
 
-   gamma, _ = topic_model.inference(corpus)
-   doc_topic_dists = _normalize(gamma)
+   assert term_freqs.shape[0] == len(dictionary), 'Term frequencies and Dictionary have different sizes {} != {}'.format(term_freqs.shape[0], len(dictionary))
+   assert doc_lengths.shape[0] == len(corpus), 'Document lengths and corpus have different sizes {} != {}'.format(doc_lengths.shape[0], len(corpus))
 
-   topics = topic_model.show_topics(formatted=False, num_words=len(vocab), num_topics=topic_model.num_topics)
-   topics_df = pd.DataFrame([dict((y,x) for x, y in tuples) for tuples in topics])[vocab]
+   if doc_topic_dists is None:
+      gamma, _ = topic_model.inference(corpus)
+      doc_topic_dists = gamma / gamma.sum(axis=1)[:, None]
+
+   topic = topic_model.state.get_lambda()
+   topic = topic / topic.sum(axis=1)[:, None]
+   topic = topic[:, fnames_argsort]
+   topics_df = pd.DataFrame(data=topic, columns=dictionary.token2id)
+   topics_df = topics_df[vocab]
+
    topic_term_dists = topics_df.values
 
    return {'topic_term_dists': topic_term_dists, 'doc_topic_dists': doc_topic_dists,
            'doc_lengths': doc_lengths, 'vocab': vocab, 'term_frequency': term_freqs}
 
-def prepare(topic_model, corpus, dictionary, **kargs):
+def prepare(topic_model, corpus, dictionary, doc_topic_dist=None, **kargs):
     """Transforms the Gensim TopicModel and related corpus and dictionary into
     the data structures needed for the visualization.
 
@@ -43,13 +54,26 @@ def prepare(topic_model, corpus, dictionary, **kargs):
     ----------
     topic_model : gensim.models.ldamodel.LdaModel
         An already trained Gensim LdaModel. The other gensim model types are
-    not supported (PRs welcome).
-    corpus : array-like list of bag of word docs in tuple form
+        not supported (PRs welcome).
+
+    corpus : array-like list of bag of word docs in tuple form or scipy CSC matrix
         The corpus in bag of word form, the same docs used to train the model.
+        The corpus is transformed into a csc matrix internally, if you intend to
+        call prepare multiple times it is a good idea to first call
+        `gensim.matutils.corpus2csc(corpus)` and pass in the csc matrix instead.
+
     For example: [(50, 3), (63, 5), ....]
+
     dictionary: gensim.corpora.Dictionary
         The dictionary object used to create the corpus. Needed to extract the
-    actual terms (not ids).
+        actual terms (not ids).
+
+    doc_topic_dist (optional): Document topic distribution from LDA (default=None)
+        The document topic distribution that is eventually visualised, if you will
+        be calling `prepare` multiple times it's a good idea to explicitly pass in
+        `doc_topic_dist` as inferring this for large corpora can be quite
+        expensive.
+
     **kwargs :
         additional keyword arguments are passed through to :func:`pyldavis.prepare`.
 
@@ -62,6 +86,10 @@ def prepare(topic_model, corpus, dictionary, **kargs):
     --------
     For example usage please see this notebook:
     http://nbviewer.ipython.org/github/bmabey/pyLDAvis/blob/master/notebooks/Gensim%20Newsgroup.ipynb
+
+    See
+    ------
+    See `pyLDAvis.prepare` for **kwargs.
     """
-    opts = fp.merge(_extract_data(topic_model, corpus, dictionary), kargs)
+    opts = fp.merge(_extract_data(topic_model, corpus, dictionary, doc_topic_dist), kargs)
     return vis_prepare(**opts)

--- a/setup.py
+++ b/setup.py
@@ -44,7 +44,7 @@ if on_rtd:
     requirements = []
 else:
     requirements = [
-        'pandas >= 0.16',
+        'pandas >= 0.17',
         'numexpr',
         'future',
         'numpy',


### PR DESCRIPTION
*This is PR is unfinished*

As it stands the `gensim.prepare` contains a lot of unnecessary iteration over lists of tuples. The aim here is to make the whole thing run faster, but this needs more testing.

I am not entirely sure if all the indexing and ordering of the vocabulary items is correct - I tested it on one lda model but I think this needs a bit more testing. I wanted to get some feedback on the PR though before I test it further.