### PR TITLE
Fixed one failing test due to differring column names.

### DIFF
--- a/tests/pyLDAvis/test_prepare.py
+++ b/tests/pyLDAvis/test_prepare.py
@@ -78,4 +78,4 @@ def test_end_to_end_with_R_examples():
     most_likely_map = pd.DataFrame(joined.groupby('Topic_o')['Topic_e'].value_counts(), columns=['count']).query('count > 100')
     most_likely_map.index.names = ['Topic_o', 'Topic_e']
     df = pd.DataFrame(most_likely_map).reset_index()
-    assert_series_equal(df['Topic_o'], df['Topic_e'])
+    assert_array_equal(df['Topic_o'].values, df['Topic_e'].values)


### PR DESCRIPTION
The column names for `df["Topic_e"]` and `df["Topic_o"]` are different which causes the test to fail, the column values however are the same.