### PR TITLE
Fixed trailing underscores in 'future' module import

### DIFF
--- a/pyLDAvis/gensim.py
+++ b/pyLDAvis/gensim.py
@@ -4,7 +4,7 @@ pyLDAvis Gensim
 Helper functions to visualize LDA models trained by Gensim
 """
 
-from __future __ import absolute_import
+from __future__ import absolute_import
 import funcy as fp
 import numpy as np
 import pandas as pd


### PR DESCRIPTION
Got rid of whitespace between 'future' and its trailing underscores. :) Thanks for your hard work on the package!
