### PR TITLE
specify scikit-bio version range

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -50,7 +50,7 @@ else:
         'numpy',
         'funcy',
         'jinja2 >= 2.7.2',
-        'scikit-bio >= 0.2.3',
+        'scikit-bio >= 0.2.3, < 0.3.0',
         'joblib >= 0.8.4'
     ]
 


### PR DESCRIPTION
scikit-bio has API changes across minor versions while in alpha/beta (i.e., pre 1.0.0) status. This change will ensure that your users pull a compatible version of scikit-bio (though I would recommend upgrading the dependency to 0.4.1, as I mentioned [here](http://stackoverflow.com/a/34335315/3424666)).