### PR TITLE
Gensim sparse corpus fix

### DIFF
--- a/pyLDAvis/gensim.py
+++ b/pyLDAvis/gensim.py
@@ -16,7 +16,7 @@ def _extract_data(topic_model, corpus, dictionary, doc_topic_dists=None):
    import gensim
 
    if not gensim.matutils.ismatrix(corpus):
-      corpus_csc = gensim.matutils.corpus2csc(corpus)
+      corpus_csc = gensim.matutils.corpus2csc(corpus, num_terms=len(dictionary))
    else:
       corpus_csc = corpus
       # Need corpus to be a streaming gensim list corpus for len and inference functions below:

--- a/pyLDAvis/gensim.py
+++ b/pyLDAvis/gensim.py
@@ -20,7 +20,7 @@ def _extract_data(topic_model, corpus, dictionary, doc_topic_dists=None):
    else:
       corpus_csc = corpus
       # Need corpus to be a streaming gensim list corpus for len and inference functions below:
-      corpus = gensim.matutils.Sparse2corpus(corpus_csc)
+      corpus = gensim.matutils.Sparse2Corpus(corpus_csc)
 
    vocab = list(dictionary.token2id.keys())
    # TODO: add the hyperparam to smooth it out? no beta in online LDA impl.. hmm..

--- a/pyLDAvis/gensim.py
+++ b/pyLDAvis/gensim.py
@@ -19,6 +19,8 @@ def _extract_data(topic_model, corpus, dictionary, doc_topic_dists=None):
       corpus_csc = gensim.matutils.corpus2csc(corpus)
    else:
       corpus_csc = corpus
+      # Need corpus to be a streaming gensim list corpus for len and inference functions below:
+      corpus = gensim.matutils.Sparse2corpus(corpus_csc)
 
    vocab = list(dictionary.token2id.keys())
    # TODO: add the hyperparam to smooth it out? no beta in online LDA impl.. hmm..


### PR DESCRIPTION
Hi bmabey, 

I noticed the gensim prepare feature attempts to handle sparse corpuses (csc) but the logic was not correctly implemented.  I have done the following:

- patched _extract_data function to allow one to prepare pyLDAvis from a csc_matrix, as I think was originally intended

- added the num_terms key-word argument to the exist call of gensim.matutils.corpus2csc to make the corpus transformation slightly more memory efficient

Thanks for the great ldavis tool for python.
--Alex