### PR TITLE
bug fix in gensim prepare

### DIFF
--- a/pyLDAvis/gensim.py
+++ b/pyLDAvis/gensim.py
@@ -49,7 +49,7 @@ def _extract_data(topic_model, corpus, dictionary, doc_topic_dists=None):
         doc_topic_dists = gamma / gamma.sum(axis=1)[:, None]
     else:
         if isinstance(doc_topic_dists, list):
-            doc_topic_dists = gensim.matutils.corpus2dense(doc_topic_dists, num_topics).T
+            doc_topic_dists = np.matrix(gensim.matutils.corpus2dense(doc_topic_dists, num_topics).T)
         elif issparse(doc_topic_dists):
             doc_topic_dists = doc_topic_dists.T.todense()
         doc_topic_dists = doc_topic_dists / doc_topic_dists.sum(axis=1)

--- a/pyLDAvis/gensim.py
+++ b/pyLDAvis/gensim.py
@@ -41,7 +41,6 @@ def _extract_data(topic_model, corpus, dictionary, doc_topic_dists=None):
        num_topics = topic_model.num_topics
 
    if doc_topic_dists is None:
-      print("doc_topic_dists is None")
       # If its an HDP model.
       if hasattr(topic_model, 'lda_beta'):
           gamma = topic_model.inference(corpus)
@@ -49,12 +48,9 @@ def _extract_data(topic_model, corpus, dictionary, doc_topic_dists=None):
           gamma, _ = topic_model.inference(corpus)
       doc_topic_dists = gamma / gamma.sum(axis=1)[:, None]
    else:
-      print("inside _extract_data", type(doc_topic_dists), issparse(doc_topic_dists))
       if isinstance(doc_topic_dists, list):
-         print("doc_topic_dists is list!")
          doc_topic_dists = gensim.matutils.corpus2dense(doc_topic_dists, num_topics).T
       elif issparse(doc_topic_dists):
-         print("doc_topic_dists is csc_matrix!", doc_topic_dists.shape)
          doc_topic_dists = doc_topic_dists.T.todense()
       doc_topic_dists = doc_topic_dists / doc_topic_dists.sum(axis=1)
 

--- a/pyLDAvis/gensim.py
+++ b/pyLDAvis/gensim.py
@@ -14,60 +14,60 @@ from . import prepare as vis_prepare
 
 
 def _extract_data(topic_model, corpus, dictionary, doc_topic_dists=None):
-   import gensim
+    import gensim
 
-   if not gensim.matutils.ismatrix(corpus):
-      corpus_csc = gensim.matutils.corpus2csc(corpus, num_terms=len(dictionary))
-   else:
-      corpus_csc = corpus
-      # Need corpus to be a streaming gensim list corpus for len and inference functions below:
-      corpus = gensim.matutils.Sparse2Corpus(corpus_csc)
+    if not gensim.matutils.ismatrix(corpus):
+        corpus_csc = gensim.matutils.corpus2csc(corpus, num_terms=len(dictionary))
+    else:
+        corpus_csc = corpus
+        # Need corpus to be a streaming gensim list corpus for len and inference functions below:
+        corpus = gensim.matutils.Sparse2Corpus(corpus_csc)
 
-   vocab = list(dictionary.token2id.keys())
-   # TODO: add the hyperparam to smooth it out? no beta in online LDA impl.. hmm..
-   # for now, I'll just make sure we don't ever get zeros...
-   beta = 0.01
-   fnames_argsort = np.asarray(list(dictionary.token2id.values()), dtype=np.int_)
-   term_freqs = corpus_csc.sum(axis=1).A.ravel()[fnames_argsort]
-   term_freqs[term_freqs == 0] = beta
-   doc_lengths = corpus_csc.sum(axis=0).A.ravel()
+    vocab = list(dictionary.token2id.keys())
+    # TODO: add the hyperparam to smooth it out? no beta in online LDA impl.. hmm..
+    # for now, I'll just make sure we don't ever get zeros...
+    beta = 0.01
+    fnames_argsort = np.asarray(list(dictionary.token2id.values()), dtype=np.int_)
+    term_freqs = corpus_csc.sum(axis=1).A.ravel()[fnames_argsort]
+    term_freqs[term_freqs == 0] = beta
+    doc_lengths = corpus_csc.sum(axis=0).A.ravel()
 
-   assert term_freqs.shape[0] == len(dictionary), 'Term frequencies and dictionary have different shape {} != {}'.format(term_freqs.shape[0], len(dictionary))
-   assert doc_lengths.shape[0] == len(corpus), 'Document lengths and corpus have different sizes {} != {}'.format(doc_lengths.shape[0], len(corpus))
+    assert term_freqs.shape[0] == len(dictionary), 'Term frequencies and dictionary have different shape {} != {}'.format(term_freqs.shape[0], len(dictionary))
+    assert doc_lengths.shape[0] == len(corpus), 'Document lengths and corpus have different sizes {} != {}'.format(doc_lengths.shape[0], len(corpus))
 
-   if hasattr(topic_model, 'lda_alpha'):
-       num_topics = len(topic_model.lda_alpha)
-   else:
-       num_topics = topic_model.num_topics
+    if hasattr(topic_model, 'lda_alpha'):
+        num_topics = len(topic_model.lda_alpha)
+    else:
+        num_topics = topic_model.num_topics
 
-   if doc_topic_dists is None:
-      # If its an HDP model.
-      if hasattr(topic_model, 'lda_beta'):
-          gamma = topic_model.inference(corpus)
-      else:
-          gamma, _ = topic_model.inference(corpus)
-      doc_topic_dists = gamma / gamma.sum(axis=1)[:, None]
-   else:
-      if isinstance(doc_topic_dists, list):
-         doc_topic_dists = gensim.matutils.corpus2dense(doc_topic_dists, num_topics).T
-      elif issparse(doc_topic_dists):
-         doc_topic_dists = doc_topic_dists.T.todense()
-      doc_topic_dists = doc_topic_dists / doc_topic_dists.sum(axis=1)
+    if doc_topic_dists is None:
+        # If its an HDP model.
+        if hasattr(topic_model, 'lda_beta'):
+            gamma = topic_model.inference(corpus)
+        else:
+            gamma, _ = topic_model.inference(corpus)
+        doc_topic_dists = gamma / gamma.sum(axis=1)[:, None]
+    else:
+        if isinstance(doc_topic_dists, list):
+            doc_topic_dists = gensim.matutils.corpus2dense(doc_topic_dists, num_topics).T
+        elif issparse(doc_topic_dists):
+            doc_topic_dists = doc_topic_dists.T.todense()
+        doc_topic_dists = doc_topic_dists / doc_topic_dists.sum(axis=1)
 
-   assert doc_topic_dists.shape[1] == num_topics, 'Document topics and number of topics do not match {} != {}'.format(doc_topic_dists.shape[1], num_topics)
+    assert doc_topic_dists.shape[1] == num_topics, 'Document topics and number of topics do not match {} != {}'.format(doc_topic_dists.shape[1], num_topics)
 
-   # get the topic-term distribution straight from gensim without
-   # iterating over tuples
-   if hasattr(topic_model, 'lda_beta'):
+    # get the topic-term distribution straight from gensim without
+    # iterating over tuples
+    if hasattr(topic_model, 'lda_beta'):
        topic = topic_model.lda_beta
-   else:
+    else:
        topic = topic_model.state.get_lambda()
-   topic = topic / topic.sum(axis=1)[:, None]
-   topic_term_dists = topic[:, fnames_argsort]
+    topic = topic / topic.sum(axis=1)[:, None]
+    topic_term_dists = topic[:, fnames_argsort]
 
-   assert topic_term_dists.shape[0] == doc_topic_dists.shape[1]
+    assert topic_term_dists.shape[0] == doc_topic_dists.shape[1]
 
-   return {'topic_term_dists': topic_term_dists, 'doc_topic_dists': doc_topic_dists,
+    return {'topic_term_dists': topic_term_dists, 'doc_topic_dists': doc_topic_dists,
            'doc_lengths': doc_lengths, 'vocab': vocab, 'term_frequency': term_freqs}
 
 def prepare(topic_model, corpus, dictionary, doc_topic_dist=None, **kwargs):


### PR DESCRIPTION
Minor bug fix to my last pull request.  

**Problem:** sparse doc_topic_dists were becoming np.matrix objs while gensim-listcorpus-like doc_topic_dists were becoming np.array objs which was not good.  Sorry for not seeing that in my last pull request. 
**Fix:** made all doc_topic_dists np.matrix objs.

On a sidenote, in gensim.py, indents seemed to sometimes be 3-spaces and other times 4-spaces.  I hope you don't mind, I changed indents in gensim.py to 4-spaces as per [PEP 8](https://www.python.org/dev/peps/pep-0008/#indentation) recommendation, and because my IDE was getting fussy.