### PR TITLE
Fixing CI and adding `sorted_terms` to PreparedData

### DIFF
--- a/.flake8
+++ b/.flake8
@@ -1,0 +1,4 @@
+[flake8]
+max-line-length = 100
+exclude = mypy-stubs
+ignore = W,E731,F403

--- a/.gitignore
+++ b/.gitignore
@@ -27,6 +27,7 @@ pip-log.txt
 .tox
 nosetests.xml
 htmlcov
+test/data/*.json
 
 # Translations
 *.mo

--- a/.travis.yml
+++ b/.travis.yml
@@ -3,12 +3,12 @@
 language: python
 
 python:
-  # - "3.4"
-  # - "3.3"
+  - "3.6"
+  - "3.5"
   - "2.7"
 
 env:
-  - DEPS="pandas jinja2=2.7.2 scipy joblib=0.8.4 numexpr pytest"
+  - DEPS="pandas jinja2>=2.7.2 scipy joblib>=0.8.4 numexpr pytest"
 
 before_install:
   # conda instructions from http://conda.pydata.org/docs/travis.html
@@ -27,6 +27,7 @@ before_install:
   - conda update -q conda
   # Useful for debugging any issues with conda
   - conda info -a
+  - export BOTO_CONFIG=/dev/null
 install:
   - conda create -n testenv --yes python=$TRAVIS_PYTHON_VERSION
   - source activate testenv

--- a/.travis.yml
+++ b/.travis.yml
@@ -8,7 +8,7 @@ python:
   - "2.7"
 
 env:
-  - DEPS="pandas jinja2>=2.7.2 scipy joblib>=0.8.4 numexpr pytest"
+  - DEPS="pandas<0.24.0a jinja2>=2.7.2 scipy joblib>=0.8.4 numexpr pytest"
 
 before_install:
   # conda instructions from http://conda.pydata.org/docs/travis.html

--- a/environment-test.yml
+++ b/environment-test.yml
@@ -1,0 +1,17 @@
+name: test-env
+channels:
+  - conda-forge/channel/main
+  - defaults
+dependencies:
+  - wheel>=0.23.0
+  - numpy>=1.9.2
+  - scipy>=0.18.0
+  - pandas>=0.17.0,<0.24.0a
+  - joblib>=0.8.4
+  - jinja2>=2.7.2
+  - numexpr
+  - pytest
+  - future
+  - funcy
+  - gensim
+  - numpydoc>=0.4

--- a/pyLDAvis/_display.py
+++ b/pyLDAvis/_display.py
@@ -5,9 +5,7 @@ import warnings
 import random
 import json
 import jinja2
-import numpy
 import re
-import os
 from ._server import serve
 from .utils import get_id, write_ipynb_local_js, NumPyEncoder
 from ._prepare import PreparedData
@@ -112,6 +110,7 @@ TEMPLATE_DICT = {"simple": SIMPLE_HTML,
                  "notebook": REQUIREJS_HTML,
                  "general": GENERAL_HTML}
 
+
 def prepared_data_to_html(data, d3_url=None, ldavis_url=None, ldavis_css_url=None,
                           template_type="general", visid=None, use_http=False):
     """Output HTML with embedded visualization
@@ -178,6 +177,7 @@ def prepared_data_to_html(data, d3_url=None, ldavis_url=None, ldavis_css_url=Non
                            vis_json=data.to_json(),
                            ldavis_css_url=ldavis_css_url)
 
+
 def display(data, local=False, **kwargs):
     """Display visualization in IPython notebook via the HTML display hook
 
@@ -221,6 +221,7 @@ def display(data, local=False, **kwargs):
 
     return HTML(prepared_data_to_html(data, **kwargs))
 
+
 def show(data, ip='127.0.0.1', port=8888, n_retries=50,
          local=True, open_browser=True, http_server=None, **kwargs):
     """Starts a local webserver and opens the visualization in a browser.
@@ -257,7 +258,7 @@ def show(data, ip='127.0.0.1', port=8888, n_retries=50,
         kwargs['d3_url'] = '/d3.js'
         kwargs['ldavis_css_url'] = '/LDAvis.css'
         files = {'/LDAvis.js': ["text/javascript",
-                               open(urls.LDAVIS_LOCAL, 'r').read()],
+                 open(urls.LDAVIS_LOCAL, 'r').read()],
                  '/LDAvis.css': ["text/css",
                                  open(urls.LDAVIS_CSS_LOCAL, 'r').read()],
                  '/d3.js': ["text/javascript",

--- a/pyLDAvis/_server.py
+++ b/pyLDAvis/_server.py
@@ -69,7 +69,7 @@ def find_open_port(ip, port, n=50):
 
 
 def serve(html, ip='127.0.0.1', port=8888, n_retries=50, files=None,
-          ipython_warning=True, open_browser=True, http_server=None):
+          ipython_warning=False, open_browser=True, http_server=None):
     """Start a server serving the given HTML, and (optionally) open a
     browser
 
@@ -102,12 +102,7 @@ def serve(html, ip='127.0.0.1', port=8888, n_retries=50, files=None,
         srvr = http_server((ip, port), Handler)
 
     if ipython_warning:
-        try:
-            __IPYTHON__
-        except:
-            pass
-        else:
-            print(IPYTHON_WARNING)
+        print(IPYTHON_WARNING)
 
     # Start the server
     print("Serving to http://{0}:{1}/    [Ctrl-C to exit]".format(ip, port))

--- a/pyLDAvis/gensim.py
+++ b/pyLDAvis/gensim.py
@@ -7,68 +7,73 @@ Helper functions to visualize LDA models trained by Gensim
 from __future__ import absolute_import
 import funcy as fp
 import numpy as np
-import pandas as pd
 from scipy.sparse import issparse
-from past.builtins import xrange
 from . import prepare as vis_prepare
 
 
 def _extract_data(topic_model, corpus, dictionary, doc_topic_dists=None):
-   import gensim
+    import gensim
 
-   if not gensim.matutils.ismatrix(corpus):
-      corpus_csc = gensim.matutils.corpus2csc(corpus, num_terms=len(dictionary))
-   else:
-      corpus_csc = corpus
-      # Need corpus to be a streaming gensim list corpus for len and inference functions below:
-      corpus = gensim.matutils.Sparse2Corpus(corpus_csc)
+    if not gensim.matutils.ismatrix(corpus):
+        corpus_csc = gensim.matutils.corpus2csc(corpus, num_terms=len(dictionary))
+    else:
+        corpus_csc = corpus
+        # Need corpus to be a streaming gensim list corpus for len and inference functions below:
+        corpus = gensim.matutils.Sparse2Corpus(corpus_csc)
 
-   vocab = list(dictionary.token2id.keys())
-   # TODO: add the hyperparam to smooth it out? no beta in online LDA impl.. hmm..
-   # for now, I'll just make sure we don't ever get zeros...
-   beta = 0.01
-   fnames_argsort = np.asarray(list(dictionary.token2id.values()), dtype=np.int_)
-   term_freqs = corpus_csc.sum(axis=1).A.ravel()[fnames_argsort]
-   term_freqs[term_freqs == 0] = beta
-   doc_lengths = corpus_csc.sum(axis=0).A.ravel()
+    vocab = list(dictionary.token2id.keys())
+    # TODO: add the hyperparam to smooth it out? no beta in online LDA impl.. hmm..
+    # for now, I'll just make sure we don't ever get zeros...
+    beta = 0.01
+    fnames_argsort = np.asarray(list(dictionary.token2id.values()), dtype=np.int_)
+    term_freqs = corpus_csc.sum(axis=1).A.ravel()[fnames_argsort]
+    term_freqs[term_freqs == 0] = beta
+    doc_lengths = corpus_csc.sum(axis=0).A.ravel()
 
-   assert term_freqs.shape[0] == len(dictionary), 'Term frequencies and dictionary have different shape {} != {}'.format(term_freqs.shape[0], len(dictionary))
-   assert doc_lengths.shape[0] == len(corpus), 'Document lengths and corpus have different sizes {} != {}'.format(doc_lengths.shape[0], len(corpus))
+    assert term_freqs.shape[0] == len(dictionary),\
+        'Term frequencies and dictionary have different shape {} != {}'.format(
+        term_freqs.shape[0], len(dictionary))
+    assert doc_lengths.shape[0] == len(corpus),\
+        'Document lengths and corpus have different sizes {} != {}'.format(
+        doc_lengths.shape[0], len(corpus))
 
-   if hasattr(topic_model, 'lda_alpha'):
-       num_topics = len(topic_model.lda_alpha)
-   else:
-       num_topics = topic_model.num_topics
+    if hasattr(topic_model, 'lda_alpha'):
+        num_topics = len(topic_model.lda_alpha)
+    else:
+        num_topics = topic_model.num_topics
 
-   if doc_topic_dists is None:
-      # If its an HDP model.
-      if hasattr(topic_model, 'lda_beta'):
-          gamma = topic_model.inference(corpus)
-      else:
-          gamma, _ = topic_model.inference(corpus)
-      doc_topic_dists = gamma / gamma.sum(axis=1)[:, None]
-   else:
-      if isinstance(doc_topic_dists, list):
-         doc_topic_dists = gensim.matutils.corpus2dense(doc_topic_dists, num_topics).T
-      elif issparse(doc_topic_dists):
-         doc_topic_dists = doc_topic_dists.T.todense()
-      doc_topic_dists = doc_topic_dists / doc_topic_dists.sum(axis=1)
+    if doc_topic_dists is None:
+        # If its an HDP model.
+        if hasattr(topic_model, 'lda_beta'):
+            gamma = topic_model.inference(corpus)
+        else:
+            gamma, _ = topic_model.inference(corpus)
+        doc_topic_dists = gamma / gamma.sum(axis=1)[:, None]
+    else:
+        if isinstance(doc_topic_dists, list):
+            doc_topic_dists = gensim.matutils.corpus2dense(doc_topic_dists, num_topics).T
+        elif issparse(doc_topic_dists):
+            doc_topic_dists = doc_topic_dists.T.todense()
+        doc_topic_dists = doc_topic_dists / doc_topic_dists.sum(axis=1)
 
-   assert doc_topic_dists.shape[1] == num_topics, 'Document topics and number of topics do not match {} != {}'.format(doc_topic_dists.shape[1], num_topics)
+    assert doc_topic_dists.shape[1] == num_topics,\
+        'Document topics and number of topics do not match {} != {}'.format(
+        doc_topic_dists.shape[1], num_topics)
 
-   # get the topic-term distribution straight from gensim without
-   # iterating over tuples
-   if hasattr(topic_model, 'lda_beta'):
-       topic = topic_model.lda_beta
-   else:
-       topic = topic_model.state.get_lambda()
-   topic = topic / topic.sum(axis=1)[:, None]
-   topic_term_dists = topic[:, fnames_argsort]
+    # get the topic-term distribution straight from gensim without
+    # iterating over tuples
+    if hasattr(topic_model, 'lda_beta'):
+        topic = topic_model.lda_beta
+    else:
+        topic = topic_model.state.get_lambda()
+    topic = topic / topic.sum(axis=1)[:, None]
+    topic_term_dists = topic[:, fnames_argsort]
 
-   assert topic_term_dists.shape[0] == doc_topic_dists.shape[1]
+    assert topic_term_dists.shape[0] == doc_topic_dists.shape[1]
 
-   return {'topic_term_dists': topic_term_dists, 'doc_topic_dists': doc_topic_dists,
-           'doc_lengths': doc_lengths, 'vocab': vocab, 'term_frequency': term_freqs}
+    return {'topic_term_dists': topic_term_dists, 'doc_topic_dists': doc_topic_dists,
+            'doc_lengths': doc_lengths, 'vocab': vocab, 'term_frequency': term_freqs}
+
 
 def prepare(topic_model, corpus, dictionary, doc_topic_dist=None, **kwargs):
     """Transforms the Gensim TopicModel and related corpus and dictionary into

--- a/pyLDAvis/graphlab.py
+++ b/pyLDAvis/graphlab.py
@@ -12,14 +12,19 @@ import pandas as pd
 import graphlab as gl
 import pyLDAvis
 
+
 def _topics_as_df(topic_model):
     tdf = topic_model['topics'].to_dataframe()
     return pd.DataFrame(np.vstack(tdf['topic_probabilities'].values), index=tdf['vocabulary'])
 
+
 def _sum_sarray_dicts(sarray):
-    counts_sf = gl.SFrame({'count_dicts': sarray}).stack('count_dicts').groupby(key_columns='X1',
-                                              operations={'count': gl.aggregate.SUM('X2')})
+    counts_sf = gl.SFrame({
+        'count_dicts': sarray}).stack('count_dicts').groupby(
+        key_columns='X1',
+        operations={'count': gl.aggregate.SUM('X2')})
     return counts_sf.unstack(column=['X1', 'count'])[0].values()[0]
+
 
 def _extract_doc_data(docs):
     doc_lengths = list(docs.apply(lambda d: np.array(d.values()).sum()))
@@ -30,6 +35,7 @@ def _extract_doc_data(docs):
 
     return {'doc_lengths': doc_lengths, 'vocab': vocab, 'term_frequency': term_freqs}
 
+
 def _extract_model_data(topic_model, docs, vocab):
     doc_topic_dists = np.vstack(topic_model.predict(docs, output_type='probabilities'))
 
@@ -38,10 +44,12 @@ def _extract_model_data(topic_model, docs, vocab):
 
     return {'topic_term_dists': topic_term_dists, 'doc_topic_dists': doc_topic_dists}
 
+
 def _extract_data(topic_model, docs):
     doc_data = _extract_doc_data(docs)
     model_data = _extract_model_data(topic_model, docs, doc_data['vocab'])
     return fp.merge(doc_data, model_data)
+
 
 def prepare(topic_model, docs, **kargs):
     """Transforms the GraphLab TopicModel and related corpus data into

--- a/pyLDAvis/sklearn.py
+++ b/pyLDAvis/sklearn.py
@@ -39,19 +39,19 @@ def _extract_data(lda_model, dtm, vectorizer):
     doc_lengths = _get_doc_lengths(dtm)
     term_freqs = _get_term_freqs(dtm)
     topic_term_dists = _get_topic_term_dists(lda_model)
+    err_msg = ('Topic-term distributions and document-term matrix'
+               'have different number of columns, {} != {}.')
 
     assert term_freqs.shape[0] == len(vocab), \
         ('Term frequencies and vocabulary are of different sizes, {} != {}.'
          .format(term_freqs.shape[0], len(vocab)))
 
     assert topic_term_dists.shape[1] == dtm.shape[1], \
-        ('Topic-term distributions and document-term matrix have different number of columns, {} != {}.'
-         .format(topic_term_dists.shape[1], len(vocab)))
+        (err_msg.format(topic_term_dists.shape[1], len(vocab)))
 
     # column dimensions of document-term matrix and topic-term distributions
     # must match first before transforming to document-topic distributions
     doc_topic_dists = _get_doc_topic_dists(lda_model, dtm)
-  
     return {'vocab': vocab,
             'doc_lengths': doc_lengths.tolist(),
             'term_frequency': term_freqs.tolist(),

--- a/pyLDAvis/urls.py
+++ b/pyLDAvis/urls.py
@@ -6,7 +6,6 @@ URLs and filepaths for the LDAvis javascript libraries
 
 import os
 from . import __path__, __version__
-import warnings
 
 __all__ = ["D3_URL", "LDAVIS_URL", "LDAVISMIN_URL", "LDAVIS_CSS_URL",
            "D3_LOCAL", "LDAVIS_LOCAL", "LDAVISMIN_LOCAL", "LDAVIS_CSS_LOCAL"]
@@ -34,10 +33,10 @@ else:
     LDAVIS_CSS_URL = WWW_JS_DIR + "ldavis.v{0}.css".format(CSS_VERSION)
 
     LDAVIS_LOCAL = os.path.join(LOCAL_JS_DIR,
-                           "ldavis.v{0}.js".format(JS_VERSION))
+                                "ldavis.v{0}.js".format(JS_VERSION))
 
     LDAVIS_CSS_LOCAL = os.path.join(LOCAL_JS_DIR,
-                           "ldavis.v{0}.css".format(CSS_VERSION))
+                                    "ldavis.v{0}.css".format(CSS_VERSION))
 
 LDAVISMIN_URL = LDAVIS_URL
 LDAVISMIN_LOCAL = LDAVIS_LOCAL

--- a/pyLDAvis/utils.py
+++ b/pyLDAvis/utils.py
@@ -9,7 +9,6 @@ import os
 import re
 import shutil
 import warnings
-from functools import wraps
 import numpy as np
 from . import urls
 
@@ -125,7 +124,9 @@ def write_ipynb_local_js(location=None, d3_src=None, ldavis_src=None, ldavis_css
         ldavis_dest = os.path.join(location, ldavisjs)
         ldavis_css_dest = os.path.join(location, ldaviscss)
 
-        for src, dest in [(d3_src, d3_dest), (ldavis_src, ldavis_dest), (ldavis_css, ldavis_css_dest)]:
+        for src, dest in [(d3_src, d3_dest),
+                          (ldavis_src, ldavis_dest),
+                          (ldavis_css, ldavis_css_dest)]:
             try:
                 shutil.copyfile(src, dest)
             except IOError:
@@ -134,8 +135,8 @@ def write_ipynb_local_js(location=None, d3_src=None, ldavis_src=None, ldavis_css
                     os.remove(dest)
                 shutil.copyfile(src, dest)
 
-
     return prefix + d3js, prefix + ldavisjs, prefix + ldaviscss
+
 
 class NumPyEncoder(json.JSONEncoder):
     def default(self, obj):

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,7 +1,7 @@
 wheel>=0.23.0
 numpy>=1.9.2
 scipy>=0.18.0
-pandas>=0.17.0
+pandas>=0.17.0,<0.24.0a
 joblib>=0.8.4
 jinja2>=2.7.2
 numexpr

--- a/setup.py
+++ b/setup.py
@@ -56,7 +56,7 @@ test_requirements = [
 
 setup(
     name='pyLDAvis',
-    version='2.1.2',
+    version='2.1.3',
     description="Interactive topic model visualization. Port of the R package.",
     long_description=readme + '\n\n' + history,
     author="Ben Mabey",

--- a/tests/pyLDAvis/test_gensim_models.py
+++ b/tests/pyLDAvis/test_gensim_models.py
@@ -1,6 +1,5 @@
 #! /usr/bin/venv python
 
-
 from gensim.models import LdaModel, HdpModel
 from gensim.corpora.dictionary import Dictionary
 import pyLDAvis.gensim
@@ -33,6 +32,7 @@ def get_corpus_dictionary():
 
     return corpus, dictionary
 
+
 def test_lda():
     """Trains a LDA model and tests the html outputs."""
     corpus, dictionary = get_corpus_dictionary()
@@ -54,6 +54,26 @@ def test_hdp():
     data = pyLDAvis.gensim.prepare(hdp, corpus, dictionary)
     pyLDAvis.save_html(data, 'index_hdp.html')
     os.remove('index_hdp.html')
+
+
+def test_sorted_terms():
+    """This tests that we can get the terms of a given topic using lambda
+    to calculate the relevance ranking. A common workflow is that once we
+    visualize the topics we modify the lambda slide and we are interested
+    in a particular lambda value, then with this function we can get the
+    terms in that order.
+    """
+    corpus, dictionary = get_corpus_dictionary()
+    lda = LdaModel(corpus=corpus, num_topics=2)
+
+    data = pyLDAvis.gensim.prepare(lda, corpus, dictionary)
+    # https://nlp.stanford.edu/events/illvi2014/papers/sievert-illvi2014.pdf
+    # lambda = 0 should rank the terms by loglift
+    # lambda = 1 should rank them by logprob.
+    sorted_terms = data.sorted_terms(topic=1, _lambda=1).to_dict()
+    assert (sorted_terms['logprob'] == sorted_terms['relevance'])
+    sorted_terms = data.sorted_terms(topic=1, _lambda=0).to_dict()
+    assert (sorted_terms['loglift'] == sorted_terms['relevance'])
 
 
 if __name__ == "__main__":

--- a/tests/pyLDAvis/test_prepare.py
+++ b/tests/pyLDAvis/test_prepare.py
@@ -48,7 +48,10 @@ def test_end_to_end_with_R_examples():
 
 
     eddf = etinfo.query('Category == "Default"')
+    eddf = eddf.reindex(sorted(eddf.columns), axis=1)
+
     oddf = otinfo.query('Category == "Default"')
+    oddf = oddf.reindex(sorted(oddf.columns), axis=1)
     assert_frame_equal(eddf, oddf)
 
     joined = pd.merge(otinfo, etinfo, how='inner', on=['Term', 'Category'], suffixes=['_o', '_e'])
@@ -67,7 +70,8 @@ def test_end_to_end_with_R_examples():
         return df
 
     emds, omds = both(lambda r: abs_basis(pd.DataFrame(r['mdsDat'])))
-    assert_frame_equal(emds, omds, check_less_precise=True)
+    assert_frame_equal(emds.reindex(sorted(oddf.columns), axis=1),
+                       omds.reindex(sorted(oddf.columns), axis=1), check_less_precise=True)
 
     def rounded_token_table(r):
        tt = pd.DataFrame(r['token.table'])

--- a/tests/pyLDAvis/test_prepare.py
+++ b/tests/pyLDAvis/test_prepare.py
@@ -6,16 +6,18 @@ import os.path as path
 import funcy as fp
 
 
-from numpy.testing import assert_array_equal, assert_allclose
+from numpy.testing import assert_array_equal
 import numpy as np
 import pandas as pd
-from pandas.util.testing import assert_frame_equal, assert_series_equal
+from pandas.util.testing import assert_frame_equal
 
 from pyLDAvis import prepare
 
 roundtrip = fp.compose(json.loads, lambda d: d.to_json(), prepare)
 
 DATA_DIR = path.join(path.dirname(path.realpath(__file__)), "../data/")
+
+
 def load_dataset(name):
     with open(path.join(DATA_DIR, '%s_input.json' % name), 'r') as j:
         data_input = json.load(j)
@@ -25,27 +27,27 @@ def load_dataset(name):
 
     return data_input, expected
 
+
 def remove_col_suffixes(df):
     df.columns = [w.split('_')[0] for w in df.columns]
     return df
 
+
 def test_end_to_end_with_R_examples():
     data_input, expected = load_dataset('movie_reviews')
-
-
-    output = roundtrip(topic_term_dists=data_input['phi'], doc_topic_dists=data_input['theta'], \
-                       doc_lengths=data_input['doc.length'], vocab=data_input['vocab'], \
-                       term_frequency=data_input['term.frequency'], R=30, lambda_step = 0.01)
+    output = roundtrip(topic_term_dists=data_input['phi'],
+                       doc_topic_dists=data_input['theta'],
+                       doc_lengths=data_input['doc.length'],
+                       vocab=data_input['vocab'],
+                       term_frequency=data_input['term.frequency'], R=30, lambda_step=0.01)
 
     assert_array_equal(np.array(expected['topic.order']), np.array(output['topic.order']))
-
 
     def both(f):
         return f(expected), f(output)
 
     assert set(expected['tinfo']['Category']) == set(output['tinfo']['Category'])
     etinfo, otinfo = both(lambda d: pd.DataFrame(d['tinfo']))
-
 
     eddf = etinfo.query('Category == "Default"')
     eddf = eddf.reindex(sorted(eddf.columns), axis=1)
@@ -55,14 +57,15 @@ def test_end_to_end_with_R_examples():
     assert_frame_equal(eddf, oddf)
 
     joined = pd.merge(otinfo, etinfo, how='inner', on=['Term', 'Category'], suffixes=['_o', '_e'])
-    ejoined = remove_col_suffixes(joined[['Term', 'Category', 'Freq_e', 'Total_e',  'loglift_e',  'logprob_e']])
-    ojoined = remove_col_suffixes(joined[['Term', 'Category', 'Freq_o', 'Total_o',  'loglift_o',  'logprob_o']])
+    ejoined = remove_col_suffixes(joined[['Term', 'Category', 'Freq_e',
+                                          'Total_e', 'loglift_e', 'logprob_e']])
+    ojoined = remove_col_suffixes(joined[['Term', 'Category', 'Freq_o', 'Total_o',
+                                          'loglift_o', 'logprob_o']])
 
-    join_percent = float(len(joined))  / len(etinfo)
+    join_percent = float(len(joined)) / len(etinfo)
     print('Topic Info join was %.0f%%' % (100 * join_percent))
     assert_frame_equal(ejoined, ojoined, check_less_precise=True)
     assert join_percent > 0.95
-
 
     def abs_basis(df):
         df.x = df.x.abs()
@@ -74,12 +77,13 @@ def test_end_to_end_with_R_examples():
                        omds.reindex(sorted(oddf.columns), axis=1), check_less_precise=True)
 
     def rounded_token_table(r):
-       tt = pd.DataFrame(r['token.table'])
-       tt.Freq =  tt.Freq.round(5)
-       return tt
+        tt = pd.DataFrame(r['token.table'])
+        tt.Freq = tt.Freq.round(5)
+        return tt
     ett, ott = both(rounded_token_table)
-    joined = pd.DataFrame(pd.merge(ott, ett, on=['Freq', 'Term'], suffixes=['_o','_e'], how='inner')\
-             .groupby('Topic_o')['Topic_e'].value_counts())
+    joined = pd.DataFrame(pd.merge(ott, ett, on=['Freq', 'Term'],
+                          suffixes=['_o', '_e'], how='inner')
+                          .groupby('Topic_o')['Topic_e'].value_counts())
     joined.columns = ['count']
     most_likely_map = joined.query('count > 100')
     most_likely_map.index.names = ['Topic_o', 'Topic_e']


### PR DESCRIPTION
This branch fixes the CI build and adds a minor functionality to the PrepareData Object. 
An important observation is that the latest pandas version degraded the performance by a lot, there issue is described here: https://github.com/pandas-dev/pandas/issues/24990 so until this gets fixed pandas is pinned to 0.23.x 

Included on this PR are:

- Fixed linting and added .flake8 file
- Changed the default python environments for CI to 2.7,3.5 and 3.6
- Added a conda environment file for local testing (`conda env create -f`)
- Pinned pandas version to avoid https://github.com/pandas-dev/pandas/issues/24990
- Added `sorted_terms` to PrepareData so when a user changes the lambda slide they can get the current term ranking.
