### PR TITLE
Add gensim Author-Topic-Model support

### DIFF
--- a/pyLDAvis/gensim_models.py
+++ b/pyLDAvis/gensim_models.py
@@ -45,9 +45,14 @@ def _extract_data(topic_model, corpus, dictionary, doc_topic_dists=None):
         # If its an HDP model.
         if hasattr(topic_model, 'lda_beta'):
             gamma = topic_model.inference(corpus)
+        # If its an Author-Topic model.
+        elif hasattr(topic_model, 'num_authors'):
+            gamma, _ = topic_model.inference(topic_model.corpus, topic_model.author2doc, topic_model.doc2author, rhot=0)
         else:
             gamma, _ = topic_model.inference(corpus)
-        doc_topic_dists = gamma / gamma.sum(axis=1)[:, None]
+        doc_topic_dists = gamma / gamma.sum(axis=1)[:, np.newaxis]
+    elif isinstance(doc_topic_dists, np.ndarray):
+        pass # Nothing to do, expects already normalized format
     else:
         if isinstance(doc_topic_dists, list):
             doc_topic_dists = gensim.matutils.corpus2dense(doc_topic_dists, num_topics).T

--- a/tests/pyLDAvis/test_gensim_models.py
+++ b/tests/pyLDAvis/test_gensim_models.py
@@ -11,12 +11,21 @@ import pyLDAvis.gensim_models as gensim_models
 
 
 def get_author2doc():
-    """Crafts a toy mapping between authors and documents."""
+    """Crafts a toy mapping between authors and documents (multiple authors per document)."""
     author2doc = {
         'john': [0, 1, 2, 3, 4, 5, 6],
         'jane': [2, 3, 4, 5, 6, 7, 8],
         'jack': [0, 2, 4, 6, 8],
         'jill': [1, 3, 5, 7]
+    }
+    return author2doc
+
+
+def get_simple_author2doc():
+    """Crafts a toy mapping between authors and documents (single author per document)."""
+    author2doc = {
+        'john': [0, 1, 2, 3, 4],
+        'jane': [5, 6, 7, 8],
     }
     return author2doc
 
@@ -47,6 +56,15 @@ def test_atm():
     data = gensim_models.prepare(atm, common_corpus, common_dictionary)
     pyLDAvis.save_html(data, 'index_atm.html')
     os.remove('index_atm.html')
+
+def test_simple_atm():
+    """Trains an Author-Topic model and tests the html outputs."""
+    atm = AuthorTopicModel(corpus=common_corpus, id2word=common_dictionary,
+                           author2doc=get_simple_author2doc(), num_topics=2)
+
+    data = gensim_models.prepare(atm, common_corpus, common_dictionary)
+    pyLDAvis.save_html(data, 'index_simple_atm.html')
+    os.remove('index_simple_atm.html')
 
 
 def test_sorted_terms():


### PR DESCRIPTION
This PR  adds the ability to use the Author-Topic Model in the same way, the LDA model is used.
It does not visualize the authors but only (as expected by pyLDAvis) the topic-term distributions.
See #112 and #84 for more details. 