### PR TITLE
Optimised calculations to work with later pandas versions, other maintenance updates

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,12 +3,13 @@
 language: python
 
 python:
+  - "3.7"
   - "3.6"
   - "3.5"
   - "2.7"
 
 env:
-  - DEPS="pandas<0.24.0a jinja2>=2.7.2 scipy joblib>=0.8.4 numexpr pytest"
+  - DEPS="pytest gensim" PY27_DEPS="pytest gensim==3.4.0 pytz"
 
 before_install:
   # conda instructions from http://conda.pydata.org/docs/travis.html
@@ -16,12 +17,12 @@ before_install:
   # We do this conditionally because it saves us some downloading if the
   # version is the same.
   - if [[ "$TRAVIS_PYTHON_VERSION" == "2.7" ]]; then
-      wget https://repo.continuum.io/miniconda/Miniconda-latest-Linux-x86_64.sh -O miniconda.sh;
+      wget https://repo.continuum.io/miniconda/Miniconda2-latest-Linux-x86_64.sh -O miniconda.sh;
     else
       wget https://repo.continuum.io/miniconda/Miniconda3-latest-Linux-x86_64.sh -O miniconda.sh;
     fi
   - bash miniconda.sh -b -p $HOME/miniconda
-  - export PATH="$HOME/miniconda/bin:$PATH"
+  - source "$HOME/miniconda/etc/profile.d/conda.sh"
   - hash -r
   - conda config --set always_yes yes --set changeps1 no
   - conda update -q conda
@@ -29,13 +30,18 @@ before_install:
   - conda info -a
   - export BOTO_CONFIG=/dev/null
 install:
-  - conda create -n testenv --yes python=$TRAVIS_PYTHON_VERSION
-  - source activate testenv
-  - conda install --yes $DEPS
-  - python setup.py install
   # download JSON data from github since travis does not have git-lfs rolled out yet
   - (cd tests/data; curl -L -O https://github.com/bmabey/pyLDAvis/raw/master/tests/data/movie_reviews_input.json && curl -L -O https://github.com/bmabey/pyLDAvis/raw/master/tests/data/movie_reviews_output.json)
   - ls -la tests/data/
+  # Python 2.7 needs a pinned version of gensim and a few other things with Conda
+  - if [[ "$TRAVIS_PYTHON_VERSION" == "2.7" ]]; then
+      conda create -n testenv --yes python=$TRAVIS_PYTHON_VERSION $PY27_DEPS;
+    else
+      conda create -n testenv --yes python=$TRAVIS_PYTHON_VERSION $DEPS;
+    fi
+  - conda activate testenv
+  - pip install .
 
 # command to run tests, e.g. python setup.py test
-script: python setup.py test
+script:
+  - pytest

--- a/pyLDAvis/_prepare.py
+++ b/pyLDAvis/_prepare.py
@@ -217,7 +217,7 @@ def _job_chunks(l, n_jobs):
 
 def _find_relevance(log_ttd, log_lift, R, lambda_):
     relevance = lambda_ * log_ttd + (1 - lambda_) * log_lift
-    return relevance.T.apply(lambda s: s.sort_values(ascending=False).index).head(R)
+    return relevance.T.apply(lambda topic: topic.nlargest(R).index)
 
 
 def _find_relevance_chunks(log_ttd, log_lift, R, lambda_seq):
@@ -231,8 +231,10 @@ def _topic_info(topic_term_dists, topic_proportion, term_frequency, term_topic_f
 
     # compute the distinctiveness and saliency of the terms:
     # this determines the R terms that are displayed when no topic is selected
-    topic_given_term = topic_term_dists / topic_term_dists.sum()
-    kernel = (topic_given_term * np.log((topic_given_term.T / topic_proportion).T))
+    tt_sum = topic_term_dists.sum()
+    topic_given_term = pd.eval("topic_term_dists / tt_sum")
+    log_1 = np.log(pd.eval("(topic_given_term.T / topic_proportion)"))
+    kernel = pd.eval("topic_given_term * log_1.T")
     distinctiveness = kernel.sum()
     saliency = term_proportion * distinctiveness
     # Order the terms for the "default" view by decreasing saliency:
@@ -249,27 +251,34 @@ def _topic_info(topic_term_dists, topic_proportion, term_frequency, term_topic_f
     default_term_info['Total'] = np.floor(default_term_info['Total'])
     ranks = np.arange(R, 0, -1)
     default_term_info['logprob'] = default_term_info['loglift'] = ranks
+    default_term_info = default_term_info.reindex(columns=[
+        "Term", "Freq", "Total", "Category", "logprob", "loglift"
+    ])
 
     # compute relevance and top terms for each topic
-    log_lift = np.log(topic_term_dists / term_proportion)
-    log_ttd = np.log(topic_term_dists)
+    log_lift = np.log(pd.eval("topic_term_dists / term_proportion")).astype("float64")
+    log_ttd = np.log(topic_term_dists).astype("float64")
     lambda_seq = np.arange(0, 1 + lambda_step, lambda_step)
 
     def topic_top_term_df(tup):
         new_topic_id, (original_topic_id, topic_terms) = tup
         term_ix = topic_terms.unique()
-        return pd.DataFrame({'Term': vocab[term_ix],
-                             'Freq': term_topic_freq.loc[original_topic_id, term_ix],
-                             'Total': term_frequency[term_ix],
-                             'logprob': log_ttd.loc[original_topic_id, term_ix].round(4),
-                             'loglift': log_lift.loc[original_topic_id, term_ix].round(4),
-                             'Category': 'Topic%d' % new_topic_id})
+        df = pd.DataFrame({'Term': vocab[term_ix],
+                           'Freq': term_topic_freq.loc[original_topic_id, term_ix],
+                           'Total': term_frequency[term_ix],
+                           'Category': 'Topic%d' % new_topic_id,
+                           'logprob': log_ttd.loc[original_topic_id, term_ix].round(4),
+                           'loglift': log_lift.loc[original_topic_id, term_ix].round(4),
+                         })
+        return df.reindex(columns=[
+            "Term", "Freq", "Total", "Category", "logprob", "loglift"
+        ])
 
     top_terms = pd.concat(Parallel(n_jobs=n_jobs)
                           (delayed(_find_relevance_chunks)(log_ttd, log_lift, R, ls)
                           for ls in _job_chunks(lambda_seq, n_jobs)))
     topic_dfs = map(topic_top_term_df, enumerate(top_terms.T.iterrows(), start_index))
-    return pd.concat([default_term_info] + list(topic_dfs), sort=True)
+    return pd.concat([default_term_info] + list(topic_dfs))
 
 
 def _token_table(topic_info, term_topic_freq, vocab, term_frequency, start_index=1):
@@ -300,7 +309,7 @@ def _token_table(topic_info, term_topic_freq, vocab, term_frequency, start_index
 
 def prepare(topic_term_dists, doc_topic_dists, doc_lengths, vocab, term_frequency,
             R=30, lambda_step=0.01, mds=js_PCoA, n_jobs=-1,
-            plot_opts={'xlab': 'PC1', 'ylab': 'PC2'}, sort_topics=True, start_index=1):
+            plot_opts=None, sort_topics=True, start_index=1):
     """Transforms the topic model distributions and related corpus data into
     the data structures needed for the visualization.
 
@@ -370,6 +379,9 @@ def prepare(topic_term_dists, doc_topic_dists, doc_lengths, vocab, term_frequenc
     :func:`display` : embed figure within the IPython notebook
     :func:`enable_notebook` : automatically embed visualizations in IPython notebook
    """
+    if plot_opts is None:
+        plot_opts = {'xlab': 'PC1', 'ylab': 'PC2'}
+
     # parse mds
     if isinstance(mds, basestring):
         mds = mds.lower()
@@ -386,6 +398,16 @@ def prepare(topic_term_dists, doc_topic_dists, doc_lengths, vocab, term_frequenc
             logging.warning('Unknown mds `%s`, switch to PCoA' % mds)
             mds = js_PCoA
 
+    # Conceptually, the items in `topic_term_dists` end up as individual rows in the
+    # DataFrame, but we can speed up ingestion by treating them as columns and
+    # transposing at the end. (This is especially true when the number of terms far
+    # exceeds the number of topics.)
+    topic_term_dist_cols = [
+        pd.Series(topic_term_dist, dtype="float64")
+        for topic_term_dist in topic_term_dists
+    ]
+    topic_term_dists = pd.concat(topic_term_dist_cols, axis=1).T
+
     topic_term_dists = _df_with_names(topic_term_dists, 'topic', 'term')
     doc_topic_dists = _df_with_names(doc_topic_dists, 'doc', 'topic')
     term_frequency = _series_with_name(term_frequency, 'term_frequency')
@@ -394,7 +416,7 @@ def prepare(topic_term_dists, doc_topic_dists, doc_lengths, vocab, term_frequenc
     _input_validate(topic_term_dists, doc_topic_dists, doc_lengths, vocab, term_frequency)
     R = min(R, len(vocab))
 
-    topic_freq = (doc_topic_dists.T * doc_lengths).T.sum()
+    topic_freq = doc_topic_dists.mul(doc_lengths, axis="index").sum()
     # topic_freq       = np.dot(doc_topic_dists.T, doc_lengths)
     if (sort_topics):
         topic_proportion = (topic_freq / topic_freq.sum()).sort_values(ascending=False)
@@ -405,7 +427,7 @@ def prepare(topic_term_dists, doc_topic_dists, doc_lengths, vocab, term_frequenc
     # reorder all data based on new ordering of topics
     topic_freq = topic_freq[topic_order]
     topic_term_dists = topic_term_dists.iloc[topic_order]
-    doc_topic_dists = doc_topic_dists[topic_order]
+    # Unused: doc_topic_dists = doc_topic_dists[topic_order]
 
     # token counts for each term-topic combination (widths of red bars)
     term_topic_freq = (topic_term_dists.T * topic_freq).T

--- a/pyLDAvis/utils.py
+++ b/pyLDAvis/utils.py
@@ -68,16 +68,19 @@ def write_ipynb_local_js(location=None, d3_src=None, ldavis_src=None, ldavis_css
     d3_url, ldavis_url : string
         The URLs to be used for loading these js files.
     """
+    nbextension = False
     if location is None:
         try:
-            from IPython.html import install_nbextension
-        except ImportError:
-            location = os.getcwd()
-            nbextension = False
-        else:
+            # Later IPython versions
+            from notebook.nbextensions import install_nbextension
             nbextension = True
-    else:
-        nbextension = False
+        except ImportError:
+            try:
+                # Older IPython versions
+                from IPython.html import install_nbextension
+                nbextension = True
+            except ImportError:
+                location = os.getcwd()
 
     if d3_src is None:
         d3_src = urls.D3_LOCAL

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,10 +1,10 @@
 wheel>=0.23.0
 numpy>=1.9.2
 scipy>=0.18.0
-pandas>=0.17.0,<0.24.0a
+pandas>=0.17.0,<0.24.0a; python_version <= "3.5"
+pandas>=0.17.0; python_version > "3.5"
 joblib>=0.8.4
 jinja2>=2.7.2
 numexpr
-pytest
 future
 funcy

--- a/setup.py
+++ b/setup.py
@@ -1,43 +1,12 @@
-#!/usr/bin/env python
-# -*- coding: utf-8 -*-
-
-import sys
 import os
 
-
-try:
-    from setuptools import setup
-    from setuptools.command.test import test as TestCommand
-except ImportError:
-    from distutils.core import setup
-    from distutils.core.command.test import test as TestCommand
-
+from setuptools import setup
 
 with open('README.rst') as readme_file:
     readme = readme_file.read()
 
 with open('HISTORY.rst') as history_file:
     history = history_file.read().replace('.. :changelog:', '')
-
-# via https://pytest.org/latest/goodpractises.html
-class PyTest(TestCommand):
-    user_options = [('pytest-args=', 'a', "Arguments to pass to py.test")]
-
-    def initialize_options(self):
-        TestCommand.initialize_options(self)
-        self.pytest_args = []
-
-    def finalize_options(self):
-        TestCommand.finalize_options(self)
-        self.test_args = []
-        self.test_suite = True
-
-    def run_tests(self):
-        #import here, cause outside the eggs aren't loaded
-        import pytest
-        errno = pytest.main(self.pytest_args)
-        sys.exit(errno)
-
 
 on_rtd = os.environ.get('READTHEDOCS', None) == 'True'
 if on_rtd:
@@ -47,16 +16,9 @@ else:
     with open('requirements.txt') as f:
         requirements = f.read().splitlines()
 
-
-test_requirements = [
-    'pytest',
-    'funcy',
-    'gensim'
-]
-
 setup(
     name='pyLDAvis',
-    version='2.1.3',
+    version='2.1.4',
     description="Interactive topic model visualization. Port of the R package.",
     long_description=readme + '\n\n' + history,
     author="Ben Mabey",
@@ -80,13 +42,10 @@ setup(
         'License :: OSI Approved :: MIT License',
         'Natural Language :: English',
         "Programming Language :: Python :: 2",
-        'Programming Language :: Python :: 2.6',
         'Programming Language :: Python :: 2.7',
         'Programming Language :: Python :: 3',
-        'Programming Language :: Python :: 3.3',
-        'Programming Language :: Python :: 3.4',
-    ],
-    test_suite='tests',
-    tests_require=test_requirements,
-    cmdclass = {'test': PyTest}
+        'Programming Language :: Python :: 3.5',
+        'Programming Language :: Python :: 3.6',
+        'Programming Language :: Python :: 3.7',
+    ]
 )


### PR DESCRIPTION
- Removed mutable default `plot_opts` from `.prepare()`
- Construct `topic_term_dists` DataFrame by column rather than by
  row
- Replaced a number of bottlenecked operations with `numexpr`
  versions using `pd.eval()`
- Fixed pandas FutureWarning and related tests (#132, #133)
- Fixed IPython shim warning for locally displayed visualisations
- Updated Travis test configuration

Should also resolve #159, and possibly #163.

The main motivation here was to fix slow `.prepare()` performance on later versions of Python/Pandas (e.g., Python 3.7, Pandas 1.0.4) -- `.prepare()` could take up to 15 or 20x longer than earlier versions in some cases.