### PR TITLE
Set sort_topic=False in prepare

### DIFF
--- a/pyLDAvis/_prepare.py
+++ b/pyLDAvis/_prepare.py
@@ -300,7 +300,7 @@ def _token_table(topic_info, term_topic_freq, vocab, term_frequency, start_index
 
 def prepare(topic_term_dists, doc_topic_dists, doc_lengths, vocab, term_frequency,
             R=30, lambda_step=0.01, mds=js_PCoA, n_jobs=-1,
-            plot_opts={'xlab': 'PC1', 'ylab': 'PC2'}, sort_topics=True, start_index=1):
+            plot_opts={'xlab': 'PC1', 'ylab': 'PC2'}, sort_topics=False, start_index=1):
     """Transforms the topic model distributions and related corpus data into
     the data structures needed for the visualization.
 


### PR DESCRIPTION
This pull request changes the default behaviour of the `prepare` function for the `sort_topic `parameter setting it to `False`. 
Having this parameter to `True `changes the order of the topic thus leading to misunderstanding between the new indexes and the old indexes (coming from gensim topic ids).

There's a linked [issue ](https://github.com/bmabey/pyLDAvis/issues/127)