### PR TITLE
Fix sklearn example: n_topics was renamed n_components

### DIFF
--- a/notebooks/sklearn.ipynb
+++ b/notebooks/sklearn.ipynb
@@ -156,10 +156,10 @@
    ],
    "source": [
     "# for TF DTM\n",
-    "lda_tf = LatentDirichletAllocation(n_topics=20, random_state=0)\n",
+    "lda_tf = LatentDirichletAllocation(n_components=20, random_state=0)\n",
     "lda_tf.fit(dtm_tf)\n",
     "# for TFIDF DTM\n",
-    "lda_tfidf = LatentDirichletAllocation(n_topics=20, random_state=0)\n",
+    "lda_tfidf = LatentDirichletAllocation(n_components=20, random_state=0)\n",
     "lda_tfidf.fit(dtm_tfidf)"
    ]
   },


### PR DESCRIPTION
![image](https://user-images.githubusercontent.com/1469823/96960444-bd997200-1502-11eb-9c11-a926ea6441d3.png)
