### PR TITLE
API included into the docs

### DIFF
--- a/HISTORY.rst
+++ b/HISTORY.rst
@@ -4,7 +4,7 @@ History
 -------
 
 3.3.1 (2021-03-24)
---------------------
+~~~~~~~~~~~~~~~~~~
 
 * Restored x-axis scale labels for term bars #200
 * import pyLDAvis.gensim_models as gensimvis
@@ -12,7 +12,7 @@ History
 * Update .gitignore for notebooks/* models, data.
 
 3.3.0 (2021-03-16)
---------------------
+~~~~~~~~~~~~~~~~~~
 
 * Python 3.7, 3.8, 3.9: dropped 2.7, 3.5, 3.6 support.
 * RuntimeWarning: divide by zero encountered in log #174
@@ -21,51 +21,51 @@ History
 * FutureWarning: pandas.util.testing is deprecated
 
 3.2.2 (2021-02-19)
---------------------
+~~~~~~~~~~~~~~~~~~
 
 * Fix browser caching of cdn.jsdelivr files.
 * update ldavis.js to match ldavis.3.0.0.js
 
 3.2.1 (2021-02-17)
---------------------
+~~~~~~~~~~~~~~~~~~
 
 * Fix missing labels and other D3.V3 to D3.V5 issues.
 * Revert the indexing changes i.e. (startIndex - 1).
 * Removed some unused GLOBALs.
 
 3.2.0 (2021-02-10)
---------------------
+~~~~~~~~~~~~~~~~~~
 
 * Switches the CDN to cdn.jsdelivr to get accurate mime types.
 
 3.1.0 (2021-02-07)
---------------------
+~~~~~~~~~~~~~~~~~~
 
 * Replaces rawgit CDN since it has been sunset.
 
 3.0.0 (2021-02-06)
----------------------
+~~~~~~~~~~~~~~~~~~
 
 * Upgrades D3 code to use the d3.v5.
 
 2.1.2 (2018-02-06)
----------------------
+~~~~~~~~~~~~~~~~~~
 
 * Fix pandas deprecation warnings.
 
 2.1.1 (2017-02-13)
----------------------
+~~~~~~~~~~~~~~~~~~
 
 * Fix `gensim` module to work with a sparse corpus #82.
 
 2.1.0 (2016-06-30)
----------------------
+~~~~~~~~~~~~~~~~~~
 
 * Added missing dependency on `scipy`.
 * Fixed term sorting that was incompatible with pandas 0.19.x.
 
 2.0.0 (2016-06-30)
----------------------
+~~~~~~~~~~~~~~~~~~
 
 * Removed dependency on `scikit-bio` by adding an internal PCoA implementation.
 * Added helper functions for scikit-learn LDA model! See the new notebook for details.
@@ -73,13 +73,13 @@ History
 * Added scikit-learn's Multi-dimensional scaling as another MDS option when scikit-learn is installed.
 
 1.5.1 (2016-04-15)
----------------------
+~~~~~~~~~~~~~~~~~~
 
 * Add sort_topics option to prepare function to allow disabling of topic re-ordering.
 
 
 1.5.0 (2016-02-20)
----------------------
+~~~~~~~~~~~~~~~~~~
 
 * Red Bar Width bug fix
 
@@ -99,48 +99,48 @@ term frequencies) as the true term frequencies increase.
 
 
 1.4.1 (2016-01-31)
----------------------
+~~~~~~~~~~~~~~~~~~
 
 * Included requirements.txt in MANIFEST to (hopefully) fix bad release.
 
 1.4.0 (2016-01-31)
----------------------
+~~~~~~~~~~~~~~~~~~
 
 * Updated to newest version of skibio for PCoA mds.
 * requirements.txt cleanup
 * New 'tsne' option for prepare, see docs and notebook for more info.
 
 
- 1.3.5 (2015-12-18)
----------------------
+1.3.5 (2015-12-18)
+~~~~~~~~~~~~~~~~~~
 
 * Add explicit version info for scikit-bio since the API has changed.
 
 
 1.3.4 (2015-11-16)
----------------------
+~~~~~~~~~~~~~~~~~~
 
 * Gensim Python typo fix in imports. :/
 
 1.3.3 (2015-11-13)
----------------------
+~~~~~~~~~~~~~~~~~~
 
 * Gensim Python 2.x fix for absolute imports.
 
 1.3.2 (2015-11-09)
----------------------
+~~~~~~~~~~~~~~~~~~
 
 * Gensim prepare 25% speed increase, thanks @mattilyra!
 * Pandas deprecation warnings are now gone.
 * Pandas v0.17 is now being used.
 
 1.3.1 (2015-11-02)
----------------------
+~~~~~~~~~~~~~~~~~~
 
 * Updates gensim and other logic to be python 3 compatible.
 
 1.3.0 (2015-08-20)
----------------------
+~~~~~~~~~~~~~~~~~~
 
 * Fixes gensim logic and makes it more robust.
 * Faster graphlab processing.
@@ -148,16 +148,16 @@ term frequencies) as the true term frequencies increase.
 * Requires recent version of pandas to avoid problems with our use of the newer `DataFrame.to_dict` API.
 
 1.2.0 (2015-06-13)
----------------------
+~~~~~~~~~~~~~~~~~~
 
 * Updates gensim logic to be clearer and work with Python 3.x.
 
 1.1.0 (2015-06-02)
----------------------
+~~~~~~~~~~~~~~~~~~
 
 * Fixes bug with GraphLab function that was producing bogus visualizations.
 
 1.0.0 (2015-05-29)
----------------------
+~~~~~~~~~~~~~~~~~~
 
 * First release on PyPI. Faithful port of R version with IPython support and helper functions for GraphLab & gensim.

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -16,6 +16,7 @@ Contents:
    usage
    contributing
    authors
+   modules/API
    history
 
 Indices and tables


### PR DESCRIPTION
In this pull request I suggest including `modules/API.rst` file into the toc of the docs to be able to see the package API without digging into the code. The second change is decreasing the level of version headers in HISTORY file. It is better to use just one header of the first level (e.g. title) on a page.