### PR TITLE
Fixing for small number of topics.

### DIFF
--- a/pyLDAvis/_prepare.py
+++ b/pyLDAvis/_prepare.py
@@ -163,7 +163,7 @@ def js_TSNE(distributions, **kwargs):
     tsne : array, shape (`n_dists`, 2)
     """
     dist_matrix = squareform(pdist(distributions, metric=_jensen_shannon))
-    model = TSNE(n_components=2, random_state=0, metric='precomputed', **kwargs)
+    model = TSNE(n_components=2, random_state=0, metric='precomputed', perplexity=min(len(dist_matrix)-1, 30), **kwargs)
     return model.fit_transform(dist_matrix)
 
 


### PR DESCRIPTION
When number of topics is less than the default perplexity for TSNE, an error is thrown. This reduces perplexity to be always smaller than the number of topics.