### PR TITLE
fixes error of get_feature_names removal

### DIFF
--- a/pyLDAvis/sklearn.py
+++ b/pyLDAvis/sklearn.py
@@ -17,7 +17,7 @@ def _get_term_freqs(dtm):
 
 
 def _get_vocab(vectorizer):
-    return vectorizer.get_feature_names()
+    return vectorizer.get_feature_names_out()
 
 
 def _row_norm(dists):


### PR DESCRIPTION
Error when using scikit-learn >= 1.2.0


pyLDAvis.sklearn.prepare raises an error due to a missing method get_feature_names() for the vectorizer argument.

AttributeError: 'CountVectorizer' object has no attribute 'get_feature_names'

Using the documentation of sklearn.feature_extraction.text.CountVectorizer as an example. It can be seen this function was deprecated in 1.0 [docs](https://scikit-learn.org/1.0/modules/generated/sklearn.feature_extraction.text.CountVectorizer.html), and removed in 1.2 [docs](https://scikit-learn.org/1.2/modules/generated/sklearn.feature_extraction.text.CountVectorizer.html). The same is true for the other vectorizer that can be used TfidfVectorizer.

The recommendation in those docs is to use get_feature_names_out() as a replacement.

Instead of returning a list of feature names, this now returns an ndarray of them. Though both being iterable types it makes no difference for the use case, where reference is only required to array-like.

This fix would also be backwards compatible to at least scikit-learn 1.0.

Tested on a fresh conda environment with Python==3.10.8, and gives expected behaviour.