### PR TITLE
Removing sklearn from requirements.

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -6,7 +6,6 @@ jinja2
 numexpr
 future
 funcy
-sklearn
 scikit-learn
 gensim
 setuptools


### PR DESCRIPTION
As #234 notes, the `sklearn` name for the package has been deprecated in favor of `scikit-learn`. I've removed `sklearn` from the `requirements.txt` file to resolve this issue.