### PR TITLE
Fixed icons disappearing in Jupyter Lab

### DIFF
--- a/pyLDAvis/js/ldavis.v1.0.0.css
+++ b/pyLDAvis/js/ldavis.v1.0.0.css
@@ -2,7 +2,7 @@
 /* Copyright 2013, AT&T Intellectual Property */
 /* MIT Licence */
 
-path {
+.slideraxis path {
   fill: none;
   stroke: none;
 }


### PR DESCRIPTION
Changed the stylesheet so that the fill: none property is only applied to the slider axis it was meant for. Instead of making all svg paths invisible.
Resolves #162